### PR TITLE
Restore MAX macro

### DIFF
--- a/src/gfx/shader.cpp
+++ b/src/gfx/shader.cpp
@@ -10,6 +10,10 @@
 
 #include "texture.h"
 
+#ifndef MAX
+	#define MAX(A,B) ((A)>(B)?(A):(B))
+#endif
+
 //typedef unsigned int GLhandle;
 
 #ifdef LOAD_EXTENSIONS_MANUALLY


### PR DESCRIPTION
MAX macro had been deleted from shader.cpp in the latest commit, and without it the code can't be compiled